### PR TITLE
List disconnected relay URLs in connection alert message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -348,12 +348,19 @@ fn start_health_tasks(
                 }
 
                 if !failed_relays.is_empty() {
+                    let failed_list: String = failed_relays
+                        .iter()
+                        .map(|url| format!("  • {}", escape_markdown(url)))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
                     let alert_msg = format!(
                         "🔌 *Relay Connection Alert*\n\n\
-                         ⚠️ Disconnected relays: {}\n\
+                         ⚠️ Disconnected relays: {}\n{}\n\
                          ✅ Connected relays: {}\n\
                          🔄 Attempting reconnection\\.\\.\\.",
                         escape_markdown(&failed_relays.len().to_string()),
+                        failed_list,
                         escape_markdown(&(relays_rc.len() - failed_relays.len()).to_string())
                     );
 


### PR DESCRIPTION
Solve #25 
Now it will show which relays are failing
Example:
```
🔌 Relay Connection Alert

⚠️ Disconnected relays: 3
  • wss://relay.xyz.io
  • wss://relay.coconut.io
  • wss://relay.star.io
✅ Connected relays: 2
🔄 Attempting reconnection...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Relay connectivity alerts now include a detailed, formatted list of each disconnected relay URL with improved readability. Previously, alerts displayed only aggregated connection counts without identifying which specific relays had failed. Users can now easily see exactly which relays are disconnected, enabling faster troubleshooting and targeted resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->